### PR TITLE
Use standard location for configuration path and naming

### DIFF
--- a/plugin_setup.php
+++ b/plugin_setup.php
@@ -1,6 +1,6 @@
 <?php
 //$DEBUG=true;
-$betaBriteSettingsFile = "/home/pi/media/plugins/betabrite.settings";
+$miniRDSSettingsFile = $settings['mediaDirectory']."/config/plugin.betabrite";
 if(isset($_POST['submit']))
 {
     $name = htmlspecialchars($_POST['station']);


### PR DESCRIPTION
Similar to the last plugin, update to use the standard location for the settings file.  NOTE: I didn't actually test this on a Pi, only my dev system, so please be sure this works there as well. ;)
